### PR TITLE
Revert binary file deleting to avoid ota failures

### DIFF
--- a/releasetools/common_ota_from_target_files
+++ b/releasetools/common_ota_from_target_files
@@ -448,8 +448,8 @@ def WriteFullOTAPackage(input_zip, output_zip):
   script.DeleteRecursive("/system")
   #script.UnpackPackageDir("recovery", "/system")
   script.UnpackPackageDir("system", "/system")
-  script.DeleteFiles(["system/bin/applypatch"] +
-                     ["system/bin/recovery"])
+  #script.DeleteFiles(["system/bin/applypatch"] +
+  #                  ["system/bin/recovery"])
 
   symlinks = CopySystemFiles(input_zip, output_zip)
   script.MakeSymlinks(symlinks)


### PR DESCRIPTION
We used to delete recovery binary file to fix for safestrap recovery in old updater-script.
This is obsolete and will cause delta ota failures on some cm source-based ROMs.
